### PR TITLE
Added 'organization' to DHIS2 sources filter

### DIFF
--- a/ckanext/harvest/plugin/__init__.py
+++ b/ckanext/harvest/plugin/__init__.py
@@ -304,7 +304,7 @@ class Harvest(MixinPlugin, p.SingletonPlugin, DefaultDatasetForm, DefaultTransla
             return facets_dict
 
         return OrderedDict([
-            ('organization', p.toolkit._('Organizations')),
+            ('organization', p.toolkit._('Organization')),
             ('frequency', p.toolkit._('Frequency')),
             ('source_type', p.toolkit._('Type')),
         ])

--- a/ckanext/harvest/plugin/__init__.py
+++ b/ckanext/harvest/plugin/__init__.py
@@ -303,9 +303,11 @@ class Harvest(MixinPlugin, p.SingletonPlugin, DefaultDatasetForm, DefaultTransla
         if package_type != 'harvest':
             return facets_dict
 
-        return OrderedDict([('frequency', 'Frequency'),
-                            ('source_type', 'Type'),
-                            ])
+        return OrderedDict([
+            ('organization', p.toolkit._('Organizations')),
+            ('frequency', p.toolkit._('Frequency')),
+            ('source_type', p.toolkit._('Type')),
+        ])
 
     def organization_facets(self, facets_dict, organization_type, package_type):
 


### PR DESCRIPTION
# Problem
- There's no `organization` filter in the sidebar for DHIS2 Sources
- It exists for datasets though

# Solution
- Update the `dataset_facets` to display the `organization` filter for `harvest` data sources

![image](https://user-images.githubusercontent.com/2634482/96726970-7304e200-13aa-11eb-9411-6df6aff69450.png)
